### PR TITLE
Change the lexer to operate on bytes, rather than runes

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -3,7 +3,6 @@ package jsonpath
 import (
 	"fmt"
 	"math"
-	"unicode"
 )
 
 func itemsToArray(ch <-chan *Item) []*Item {
@@ -25,8 +24,12 @@ func toArrayUntil(ch <-chan *Item, until func(*Item) bool) []*Item {
 	return vals
 }
 
-func isNumericStart(r rune) bool {
-	return r == '-' || unicode.IsDigit(r)
+func isDigit(cur int) bool {
+	return (cur >= '0' && cur <= '9')
+}
+
+func isNumericStart(r int) bool {
+	return r == '-' || isDigit(r)
 }
 
 // Testing

--- a/path.go
+++ b/path.go
@@ -14,7 +14,7 @@ func GetByString(input, path string) <-chan []interface{} {
 	return Get(reader, path)
 }
 
-func Get(rs io.RuneScanner, path string) <-chan []interface{} {
+func Get(rs io.Reader, path string) <-chan []interface{} {
 	query, err := parsePath(path)
 	if err != nil {
 		return nil

--- a/path_states.go
+++ b/path_states.go
@@ -1,7 +1,5 @@
 package jsonpath
 
-import "unicode"
-
 const (
 	pathEOF = iota
 	pathError
@@ -119,7 +117,7 @@ func lexPathArray(l *lexer) stateFn {
 	cur = l.peek()
 	switch {
 	case isNumericStart(cur):
-		l.acceptWhere(unicode.IsDigit)
+		l.acceptWhere(isDigit)
 		l.emit(pathIndex)
 	case cur == '*':
 		l.take()


### PR DESCRIPTION
This avoids the overhead of doing UTF-8 parsing of the input. It's safe
to operate on bytes, because anything outside the ASCII set will have
high bits set, and won't conflict with any symbols used in JSON syntax.

This improves performance by roughly 20%.

Before: BenchmarkLexerJSON           100          19685354 ns/op
After: BenchmarkLexerJSON	     100	  15877420 ns/op