### PR TITLE
Pass Items over the channel rather than *Items

### DIFF
--- a/evaluate.go
+++ b/evaluate.go
@@ -19,7 +19,7 @@ func newEvaluator() *evaluator {
 	return e
 }
 
-func (e *evaluator) perform(jsonStream <-chan *Item, keys []*key) error {
+func (e *evaluator) perform(jsonStream <-chan Item, keys []*key) error {
 	if len(keys) == 0 {
 		val, err := traverseValueTree(jsonStream, true)
 		if err != nil {
@@ -160,7 +160,7 @@ func (e *evaluator) run(l *lexer, keys []*key) chan []interface{} {
 	return e.results
 }
 
-func traverseUntilEnd(jsonStream <-chan *Item, open, end int) error {
+func traverseUntilEnd(jsonStream <-chan Item, open, end int) error {
 	jsonStack := &stack{}
 	jsonStack.Push(open)
 
@@ -184,7 +184,7 @@ looper:
 	return nil
 }
 
-func traverseValueTree(jsonStream <-chan *Item, capture bool) (string, error) {
+func traverseValueTree(jsonStream <-chan Item, capture bool) (string, error) {
 	jsonStack := &stack{}
 	buffer := bytes.NewBufferString("")
 

--- a/misc.go
+++ b/misc.go
@@ -5,19 +5,21 @@ import (
 	"math"
 )
 
-func itemsToArray(ch <-chan *Item) []*Item {
-	vals := make([]*Item, 0)
+func itemsToArray(ch <-chan Item) []*Item {
+	vals := make([]Item, 0)
+	valPtrs := make([]*Item, 0)
 	for l := range ch {
 		vals = append(vals, l)
+		valPtrs = append(valPtrs, &vals[len(vals)-1])
 	}
-	return vals
+	return valPtrs
 }
 
-func toArrayUntil(ch <-chan *Item, until func(*Item) bool) []*Item {
-	vals := make([]*Item, 0)
+func toArrayUntil(ch <-chan Item, until func(*Item) bool) []Item {
+	vals := make([]Item, 0)
 	for i := range ch {
 		vals = append(vals, i)
-		if until(i) {
+		if until(&i) {
 			break
 		}
 	}

--- a/path.go
+++ b/path.go
@@ -46,7 +46,7 @@ type key struct {
 	keys map[string]struct{}
 }
 
-func genIndexKey(path <-chan *Item) (*key, error) {
+func genIndexKey(path <-chan Item) (*key, error) {
 	k := &key{}
 	first := <-path
 	switch first.typ {
@@ -91,7 +91,7 @@ func parsePath(path string) ([]*key, error) {
 	return toQuery(lexer.items)
 }
 
-func toQuery(path <-chan *Item) ([]*key, error) {
+func toQuery(path <-chan Item) ([]*key, error) {
 	query := make([]*key, 0)
 	for p := range path {
 		switch p.typ {

--- a/path_test.go
+++ b/path_test.go
@@ -8,15 +8,15 @@ import (
 
 func TestPathToQuery(t *testing.T) {
 	as := assert.New(t)
-	items := make(chan *Item, 100)
-	items <- &Item{typ: pathRoot, val: `$`}
-	items <- &Item{typ: pathPeriod, val: `.`}
-	items <- &Item{typ: pathKey, val: `aKey`}
-	items <- &Item{typ: pathPeriod, val: `.`}
-	items <- &Item{typ: pathKey, val: `bKey`}
-	items <- &Item{typ: pathBracketLeft, val: `[`}
-	items <- &Item{typ: pathIndex, val: `234`}
-	items <- &Item{typ: pathBracketRight, val: `]`}
+	items := make(chan Item, 100)
+	items <- Item{typ: pathRoot, val: `$`}
+	items <- Item{typ: pathPeriod, val: `.`}
+	items <- Item{typ: pathKey, val: `aKey`}
+	items <- Item{typ: pathPeriod, val: `.`}
+	items <- Item{typ: pathKey, val: `bKey`}
+	items <- Item{typ: pathBracketLeft, val: `[`}
+	items <- Item{typ: pathIndex, val: `234`}
+	items <- Item{typ: pathBracketRight, val: `]`}
 
 	close(items)
 
@@ -35,25 +35,25 @@ func TestPathToQuery(t *testing.T) {
 func TestTraverseValueTree(t *testing.T) {
 	as := assert.New(t)
 
-	items := make(chan *Item, 100)
-	items <- &Item{typ: jsonBraceLeft, val: `{`}
-	items <- &Item{typ: jsonKey, val: `"aKey"`}
-	items <- &Item{typ: jsonColon, val: `:`}
-	items <- &Item{typ: jsonBraceLeft, val: `{`}
-	items <- &Item{typ: jsonKey, val: `"bKey"`}
-	items <- &Item{typ: jsonColon, val: `:`}
-	items <- &Item{typ: jsonBracketLeft, val: `[`}
-	items <- &Item{typ: jsonNumber, val: `123`}
-	items <- &Item{typ: jsonComma, val: `,`}
-	items <- &Item{typ: jsonNumber, val: `456`}
-	items <- &Item{typ: jsonBracketRight, val: `]`}
-	items <- &Item{typ: jsonBraceRight, val: `}`}
-	items <- &Item{typ: jsonBraceRight, val: `}`}
+	items := make(chan Item, 100)
+	items <- Item{typ: jsonBraceLeft, val: `{`}
+	items <- Item{typ: jsonKey, val: `"aKey"`}
+	items <- Item{typ: jsonColon, val: `:`}
+	items <- Item{typ: jsonBraceLeft, val: `{`}
+	items <- Item{typ: jsonKey, val: `"bKey"`}
+	items <- Item{typ: jsonColon, val: `:`}
+	items <- Item{typ: jsonBracketLeft, val: `[`}
+	items <- Item{typ: jsonNumber, val: `123`}
+	items <- Item{typ: jsonComma, val: `,`}
+	items <- Item{typ: jsonNumber, val: `456`}
+	items <- Item{typ: jsonBracketRight, val: `]`}
+	items <- Item{typ: jsonBraceRight, val: `}`}
+	items <- Item{typ: jsonBraceRight, val: `}`}
 
 	// Should not capture these
-	items <- &Item{typ: jsonNumber, val: `332`}
-	items <- &Item{typ: jsonComma, val: `,`}
-	items <- &Item{typ: jsonBraceLeft, val: `{`}
+	items <- Item{typ: jsonNumber, val: `332`}
+	items <- Item{typ: jsonComma, val: `,`}
+	items <- Item{typ: jsonBraceLeft, val: `{`}
 	close(items)
 
 	res, err := traverseValueTree(items, true)


### PR DESCRIPTION
I was messing with this again and found that avoiding the pointer makes things much faster. It's not obvious why, but I suspect it reduces the amount of garbage collection that needs to happen.

I still think that an interface will be a lot faster than a channel. For example, this is the interface that's used in the Go assembler:

// A TokenReader is like a reader, but returns lex tokens of type Token. It also can tell you what
// the text of the most recently returned token is, and where it was found.
// The underlying scanner elides all spaces except newline, so the input looks like a  stream of
// Tokens; original spacing is lost but we don't need it.
type TokenReader interface {
       // Next returns the next token.
       Next() ScanToken
       // The following methods all refer to the most recent token returned by Next.
       // Text returns the original string representation of the token.
       Text() string
       // File reports the source file name of the token.
       File() string
       // Line reports the source line number of the token.
       Line() int
       // SetPos sets the file and line number.
       SetPos(line int, file string)
       // Close does any teardown required.
       Close()
}

We could try something similar. But if we end up keeping the channel, this commit is a simple speedup.