### PR TITLE
Push takeString logic to the lexers for better performance

### DIFF
--- a/json_states.go
+++ b/json_states.go
@@ -176,7 +176,7 @@ func stateJsonAfterValue(l lexer, state *intStack) stateFn {
 
 func stateJsonKey(l lexer, state *intStack) stateFn {
 	ignoreSpaceRun(l)
-	if err := takeString(l); err != nil {
+	if err := l.takeString(); err != nil {
 		return l.errorf(err.Error())
 	}
 	l.emit(jsonKey)
@@ -222,7 +222,7 @@ func stateJsonValue(l lexer, state *intStack) stateFn {
 
 func stateJsonString(l lexer, state *intStack) stateFn {
 	//ignoreSpaceRun(l)
-	if err := takeString(l); err != nil {
+	if err := l.takeString(); err != nil {
 		return l.errorf(err.Error())
 	}
 	l.emit(jsonString)

--- a/lex.go
+++ b/lex.go
@@ -24,6 +24,7 @@ type tokenReader interface {
 type lexer interface {
 	tokenReader
 	take() int
+	takeString() error
 	peek() int
 	emit(int)
 	ignore()

--- a/misc.go
+++ b/misc.go
@@ -63,32 +63,6 @@ func takeNumeric(l lexer) error {
 	return nil
 }
 
-func takeString(l lexer) error {
-	cur := l.take()
-	if cur != '"' {
-		return fmt.Errorf("Expected \" as start of string instead of %#U", cur)
-	}
-
-	var previous int
-looper:
-	for {
-		cur = l.take()
-		switch cur {
-		case '"':
-			if previous == noValue || previous != '\\' {
-				break looper
-			} else {
-				l.take()
-			}
-		case eof:
-			return fmt.Errorf("Unexpected EOF in string")
-		}
-
-		previous = cur
-	}
-	return nil
-}
-
 func takeDigits(l lexer) {
 	for {
 		d := l.peek()

--- a/path_states.go
+++ b/path_states.go
@@ -76,7 +76,7 @@ func lexKey(l lexer, state *intStack) stateFn {
 		l.emit(pathWildcard)
 		return lexPathAfterKey
 	case '"':
-		takeString(l)
+		l.takeString()
 		l.emit(pathKey)
 
 		return lexPathAfterKey


### PR DESCRIPTION
The lexers can be more efficient about iterating through the bytes than
an external function. With takeString as a lexer method, there's no need
to perform multiple function calls for every byte. The overhead of the
function calls is very significant.

The byte lexer version is most efficient. It steps over the input
directly, and maintains a local variable with the current offset. When
it returns, it updates l.pos. Avoiding intermediate writes to l.pos
means the compiler can track the position in a register.

The reader lexer effectively inlines a simplified version of
peek()/take(). It avoids setting nextByte because this isn't used in the
context of parsing a string. It still has to call ReadByte() and
WriteByte(), though.

Benchmark results:

benchmark                      old ns/op     new ns/op     delta
BenchmarkUnmarshalMix          4389407       4472287       +1.89%
BenchmarkDecodeMix             1595274       1594484       -0.05%
BenchmarkBytesMix              1550321       1232586       -20.49%
BenchmarkReaderMix             3878020       3368036       -13.15%

The same optimization could potentially be applied for takeDigits(),
takeNumeric(), at the cost of more complexity in the lexer
implementations. The optimizations will probably be less helpful for
numeric types because strings can be much longer than numbers.