### PR TITLE
Faster whitespace skipping

### DIFF
--- a/bytes_lex.go
+++ b/bytes_lex.go
@@ -10,7 +10,6 @@ type blexer struct {
 	input []byte // the []byte being scanned.
 	start Pos    // start position of this Item.
 	pos   Pos    // current position in the input
-	width Pos    // width of last rune read from input
 }
 
 func NewBytesLexer(input []byte, initial stateFn) *blexer {
@@ -77,8 +76,19 @@ func (l *blexer) peek() int {
 
 func (l *blexer) emit(t int) {
 	l.setItem(t, l.start, l.input[l.start:l.pos])
-	l.start = l.pos
 	l.hasItem = true
+
+	// Ignore whitespace after this token
+	for int(l.pos) < len(l.input) {
+		r := l.input[l.pos]
+		if r == ' ' || r == '\t' || r == '\r' || r == '\n' {
+			l.pos++
+		} else {
+			break
+		}
+	}
+
+	l.start = l.pos
 }
 
 func (l *blexer) setItem(typ int, pos Pos, val []byte) {

--- a/json_states.go
+++ b/json_states.go
@@ -40,7 +40,6 @@ var jsonTokenNames = map[int]string{
 
 var JSON = lexJsonRoot
 
-// TODO: Handle array at root as well as object
 func lexJsonRoot(l lexer, state *intStack) stateFn {
 	ignoreSpaceRun(l)
 	cur := l.peek()
@@ -79,7 +78,6 @@ func stateJsonArrayOpen(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonObject(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	var next stateFn
 	cur := l.peek()
 	switch cur {
@@ -101,7 +99,6 @@ func stateJsonObject(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonArray(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	var next stateFn
 	cur := l.peek()
 	switch cur {
@@ -121,7 +118,6 @@ func stateJsonArray(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonAfterValue(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	cur := l.take()
 	top, ok := state.peek()
 	val := noValue
@@ -175,7 +171,6 @@ func stateJsonAfterValue(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonKey(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	if err := l.takeString(); err != nil {
 		return l.errorf(err.Error())
 	}
@@ -185,8 +180,6 @@ func stateJsonKey(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonColon(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
-
 	cur := l.take()
 	if cur != ':' {
 		return l.errorf("Expected ':' after key string instead of %#U", cur)
@@ -197,7 +190,6 @@ func stateJsonColon(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonValue(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	cur := l.peek()
 
 	switch cur {
@@ -221,7 +213,6 @@ func stateJsonValue(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonString(l lexer, state *intStack) stateFn {
-	//ignoreSpaceRun(l)
 	if err := l.takeString(); err != nil {
 		return l.errorf(err.Error())
 	}
@@ -230,7 +221,6 @@ func stateJsonString(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonNumber(l lexer, state *intStack) stateFn {
-	//ignoreSpaceRun(l)
 	if err := takeNumeric(l); err != nil {
 		return l.errorf(err.Error())
 	}
@@ -239,7 +229,6 @@ func stateJsonNumber(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonBool(l lexer, state *intStack) stateFn {
-	//ignoreSpaceRun(l)
 	cur := l.peek()
 	var match []byte
 	switch cur {
@@ -257,7 +246,6 @@ func stateJsonBool(l lexer, state *intStack) stateFn {
 }
 
 func stateJsonNull(l lexer, state *intStack) stateFn {
-	//ignoreSpaceRun(l)
 	if !takeExactSequence(l, nullBytes) {
 		return l.errorf("Could not parse value as 'null'")
 	}

--- a/misc.go
+++ b/misc.go
@@ -74,6 +74,8 @@ func takeDigits(l lexer) {
 	}
 }
 
+// Only used at the very beginning of parsing. After that, the emit() function
+// automatically skips whitespace.
 func ignoreSpaceRun(l lexer) {
 	for {
 		r := l.peek()

--- a/path_states.go
+++ b/path_states.go
@@ -122,7 +122,6 @@ func lexPathArrayClose(l lexer, state *intStack) stateFn {
 }
 
 func lexPathAfterValue(l lexer, state *intStack) stateFn {
-	ignoreSpaceRun(l)
 	cur := l.take()
 	if cur != eof {
 		return l.errorf("Expected EOF instead of %#U", cur)

--- a/reader_lex.go
+++ b/reader_lex.go
@@ -90,6 +90,25 @@ func (l *rlexer) emit(t int) {
 	l.setItem(t, l.pos, l.lexeme.Bytes())
 	l.pos += Pos(l.lexeme.Len())
 	l.hasItem = true
+
+	// Ignore whitespace after this token
+	if l.nextByte == noValue {
+		l.peek()
+	}
+
+	for l.nextByte != eof {
+		if l.nextByte == ' ' || l.nextByte == '\t' || l.nextByte == '\r' || l.nextByte == '\n' {
+			l.pos++
+			r, err := l.bufInput.ReadByte()
+			if err == io.EOF {
+				l.nextByte = eof
+			} else {
+				l.nextByte = int(r)
+			}
+		} else {
+			break
+		}
+	}
 }
 
 func (l *rlexer) setItem(typ int, pos Pos, val []byte) {


### PR DESCRIPTION
In the existing code, there were many places where ignoreSpaceRun() had
to be called. This did a series of peek()/take() calls and was quite
slow for the same reasons as the old takeString().

This commit make the emit() function always skip whitespace after a
token. The whitespace skipping is implemented in a faster way than using
peek()/take().

In addition to improving performance, this also simplifies the
json_states code because it doesn't have to check for whitespace anymore
(except at the beginning of parsing).

Additional improvement from this commit (relative to only the takeString
optimization):

benchmark                      old ns/op     new ns/op     delta
BenchmarkUnmarshalMix          4472287       4259434       -4.76%
BenchmarkDecodeMix             1594484       1604531       +0.63%
BenchmarkBytesMix              1232586       1044650       -15.25%
BenchmarkReaderMix             3368036       3174426       -5.75%

Cumulative improvement of this commit and takeString optimization
together:

benchmark                      old ns/op     new ns/op     delta
BenchmarkUnmarshalMix          4389407       4259434       -2.96%
BenchmarkDecodeMix             1595274       1604531       +0.58%
BenchmarkBytesMix              1550321       1044650       -32.62%
BenchmarkReaderMix             3878020       3174426       -18.14%